### PR TITLE
fix constant_position for prepared statement

### DIFF
--- a/pg_qualstats.c
+++ b/pg_qualstats.c
@@ -1420,6 +1420,10 @@ pgqs_process_opexpr(OpExpr *expr, pgqsWalkerContext * context)
 				position = constant->location;
 			}
 
+			if (var != NULL) {
+				position = var->location;
+			}
+			
 			/* local hash, no lock needed */
 			entry = (pgqsEntry *) hash_search(pgqs_localhash, &key, HASH_ENTER,
 					&found);


### PR DESCRIPTION
Hello Dalibo Team.
This PR permit to store the constant position for variables in prepared Statement in this pgqsEntry store.

To reproduce the problem :

create a table with 2 or more columns.
create a program which use a prepared statement (I used a java program) for an select query.

select * from pg_qualstat()

with previous version : 
you can see null or -X for constant_position.
If you rexecute the test program, the constant_position decrement.

with the pr version
you will have constant_position

The constant_position will permit to have an explain plan for prepared statement in powa-web with the good order for variable.

Regards