### PR TITLE
 Remove extraneous parentheses to avoid clang warning

### DIFF
--- a/pg_qualstats.c
+++ b/pg_qualstats.c
@@ -1517,7 +1517,7 @@ pgqs_whereclause_tree_walker(Node *node, pgqsWalkerContext *context)
 					context->qualid = 0;
 					context->uniquequalid = 0;
 				}
-				if ((boolexpr->boolop == AND_EXPR))
+				if (boolexpr->boolop == AND_EXPR)
 				{
 					context->uniquequalid = hashExpr((Expr *) boolexpr, context, pgqs_track_constants);
 					context->qualid = hashExpr((Expr *) boolexpr, context, false);


### PR DESCRIPTION
Hello,

I tried to compile pg_qualstats on debian stretch, which seems to use clang by default. clang report this warning:
```
[...]
/usr/bin/clang-3.9 -Wno-ignored-attributes -fno-strict-aliasing -fwrapv -O2  -I. -I./ -I/usr/include/postgresql/11/server -I/usr/include/postgresql/internal  -Wdate-time -D_FORTIFY_SOURCE=2 -D_GNU_SOURCE -I/usr/include/libxml2  -I/usr/include/mit-krb5 -flto=thin -emit-llvm -c -o pg_qualstats.bc pg_qualstats.c
pg_qualstats.c:1520:27: warning: equality comparison with extraneous parentheses
      [-Wparentheses-equality]
                                if ((boolexpr->boolop == AND_EXPR))
                                     ~~~~~~~~~~~~~~~~~^~~~~~~~~~~
pg_qualstats.c:1520:27: note: remove extraneous parentheses around the comparison to silence this
      warning
                                if ((boolexpr->boolop == AND_EXPR))
                                    ~                 ^          ~
pg_qualstats.c:1520:27: note: use '=' to turn this equality comparison into an assignment
                                if ((boolexpr->boolop == AND_EXPR))
                                                      ^~
                                                      =

```