### PR TITLE
pg_qualstats.max default value typo?

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -62,7 +62,7 @@ The following GUCs can be configured, in postgresql.conf:
   this GUC will considerably reduce the number of entries necessary to keep
   track of predicates.
 - *pg_qualstats.max*: the maximum number of predicated and query text tracked
-  (defaults to 1000)
+  (defaults to 100)
 - *pg_qualstats.resolve_oids* (boolean, default false): whether or not
   pg_qualstats should resolve oids at query time, or juste store the oids.
   Enabling this parameter makes the data analysis much more easy, since a


### PR DESCRIPTION
It [seems](https://github.com/powa-team/pg_qualstats/blob/master/pg_qualstats.c#L392) like the default value of `pg_qualstats.max` is 100, not 1000. Am I right?