### PR TITLE
Fix postgres 19 support

### DIFF
--- a/pg_qualstats.c
+++ b/pg_qualstats.c
@@ -45,6 +45,9 @@
 #if PG_VERSION_NUM >= 150000
 #include "common/pg_prng.h"
 #endif
+#if PG_VERSION_NUM >= 190000
+#include "executor/instrument.h"
+#endif
 #include "fmgr.h"
 #include "funcapi.h"
 #include "mb/pg_wchar.h"


### PR DESCRIPTION
Commit postgres/postgres@fba4233 removed include "executor/instrument.h" from
src/include/nodes/execnodes.h.