### PR TITLE
Fix Postgres 19 support

### DIFF
--- a/pg_qualstats.c
+++ b/pg_qualstats.c
@@ -1898,12 +1898,20 @@ pgqs_shmem_startup(void)
 	queryinfo.hash = pgqs_uint32_hashfn;
 #endif
 	pgqs_hash = ShmemInitHash("pg_qualstatements_hash",
+#if PG_VERSION_NUM >= 190000
+							  pgqs_max,
+#else
 							  pgqs_max, pgqs_max,
+#endif
 							  &info,
 							  HASH_ELEM | HASH_FUNCTION | HASH_FIXED_SIZE);
 
 	pgqs_query_examples_hash = ShmemInitHash("pg_qualqueryexamples_hash",
+#if PG_VERSION_NUM >= 190000
+											 pgqs_max,
+#else
 											 pgqs_max, pgqs_max,
+#endif
 											 &queryinfo,
 
 /* On PG > 9.5, use the HASH_BLOBS optimization for uint32 keys. */


### PR DESCRIPTION
Commit https://github.com/postgres/postgres/commit/9ebe1c4 replaced the two init_size and max_size
arguments in the ShmemInitHash function with a single nelems argument.