### PR TITLE
Import upstream explain_filter funciton in regression tests

### DIFF
--- a/expected/00_setup.out
+++ b/expected/00_setup.out
@@ -2,3 +2,26 @@
 -- ensure that custom schema works as expected.
 CREATE SCHEMA "PGQS";
 CREATE EXTENSION pg_qualstats WITH SCHEMA "PGQS";
+-- based on upstream function of the same name
+CREATE FUNCTION explain_filter(text) RETURNS SETOF text
+LANGUAGE plpgsql as
+$$
+DECLARE
+    ln text;
+BEGIN
+    FOR ln IN EXECUTE $1
+    LOOP
+        -- Replace any numeric word with just 'N'
+        ln := regexp_replace(ln, '-?\m\d+\M', 'N', 'g');
+        -- In sort output, the above won't match units-suffixed numbers
+        ln := regexp_replace(ln, '\m\d+kB', 'NkB', 'g');
+        -- Ignore text-mode buffers output because it varies depending
+        -- on the system state
+        CONTINUE WHEN (ln ~ ' +Buffers: .*');
+        -- Ignore text-mode "Planning:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln = 'Planning:');
+        RETURN NEXT ln;
+    END LOOP;
+END;
+$$;

--- a/expected/03_joinqual.out
+++ b/expected/03_joinqual.out
@@ -23,7 +23,7 @@ SELECT "PGQS".pg_qualstats_reset();
  
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT count(*)
+SELECT explain_filter($$EXPLAIN (COSTS OFF) SELECT count(*)
 FROM lineitem, part
 WHERE
     p_partkey = l_partkey
@@ -37,17 +37,18 @@ WHERE
       WHERE
         l_partkey = p_partkey
 );
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+$$);
+                                          explain_filter                                           
+---------------------------------------------------------------------------------------------------
  Aggregate
    ->  Hash Join
          Hash Cond: (lineitem.l_partkey = part.p_partkey)
-         Join Filter: (lineitem.l_quantity < (SubPlan 1))
+         Join Filter: (lineitem.l_quantity < (SubPlan N))
          ->  Seq Scan on lineitem
          ->  Hash
                ->  Seq Scan on part
-                     Filter: ((p_brand = 'Brand#23'::bpchar) AND (p_container = 'MED BOX'::bpchar))
-         SubPlan 1
+                     Filter: ((p_brand = 'Brand#N'::bpchar) AND (p_container = 'MED BOX'::bpchar))
+         SubPlan N
            ->  Aggregate
                  ->  Seq Scan on lineitem lineitem_1
                        Filter: (l_partkey = part.p_partkey)
@@ -84,7 +85,7 @@ SELECT "PGQS".pg_qualstats_reset();
  
 (1 row)
 
-EXPLAIN (COSTS OFF) SELECT count(*)
+SELECT explain_filter($$EXPLAIN (COSTS OFF) SELECT count(*)
 FROM lineitem, part
 WHERE
     p_partkey = l_partkey
@@ -98,20 +99,21 @@ WHERE
       WHERE
         l_partkey = p_partkey
 );
-                                             QUERY PLAN                                             
-----------------------------------------------------------------------------------------------------
+$$);
+                                          explain_filter                                           
+---------------------------------------------------------------------------------------------------
  Aggregate
    ->  Merge Join
          Merge Cond: (part.p_partkey = lineitem.l_partkey)
-         Join Filter: (lineitem.l_quantity < (SubPlan 1))
+         Join Filter: (lineitem.l_quantity < (SubPlan N))
          ->  Sort
                Sort Key: part.p_partkey
                ->  Seq Scan on part
-                     Filter: ((p_brand = 'Brand#23'::bpchar) AND (p_container = 'MED BOX'::bpchar))
+                     Filter: ((p_brand = 'Brand#N'::bpchar) AND (p_container = 'MED BOX'::bpchar))
          ->  Sort
                Sort Key: lineitem.l_partkey
                ->  Seq Scan on lineitem
-         SubPlan 1
+         SubPlan N
            ->  Aggregate
                  ->  Seq Scan on lineitem lineitem_1
                        Filter: (l_partkey = part.p_partkey)

--- a/test/sql/00_setup.sql
+++ b/test/sql/00_setup.sql
@@ -2,3 +2,27 @@
 -- ensure that custom schema works as expected.
 CREATE SCHEMA "PGQS";
 CREATE EXTENSION pg_qualstats WITH SCHEMA "PGQS";
+
+-- based on upstream function of the same name
+CREATE FUNCTION explain_filter(text) RETURNS SETOF text
+LANGUAGE plpgsql as
+$$
+DECLARE
+    ln text;
+BEGIN
+    FOR ln IN EXECUTE $1
+    LOOP
+        -- Replace any numeric word with just 'N'
+        ln := regexp_replace(ln, '-?\m\d+\M', 'N', 'g');
+        -- In sort output, the above won't match units-suffixed numbers
+        ln := regexp_replace(ln, '\m\d+kB', 'NkB', 'g');
+        -- Ignore text-mode buffers output because it varies depending
+        -- on the system state
+        CONTINUE WHEN (ln ~ ' +Buffers: .*');
+        -- Ignore text-mode "Planning:" line because whether it's output
+        -- varies depending on the system state
+        CONTINUE WHEN (ln = 'Planning:');
+        RETURN NEXT ln;
+    END LOOP;
+END;
+$$;

--- a/test/sql/03_joinqual.sql
+++ b/test/sql/03_joinqual.sql
@@ -24,7 +24,7 @@ SET enable_mergejoin = false;
 -- Make sure that installcheck won't find previous data
 SELECT "PGQS".pg_qualstats_reset();
 
-EXPLAIN (COSTS OFF) SELECT count(*)
+SELECT explain_filter($$EXPLAIN (COSTS OFF) SELECT count(*)
 FROM lineitem, part
 WHERE
     p_partkey = l_partkey
@@ -38,6 +38,7 @@ WHERE
       WHERE
         l_partkey = p_partkey
 );
+$$);
 
 SELECT lc.relname, la.attname,
     opno::regoperator,
@@ -60,7 +61,7 @@ SET enable_mergejoin = true;
 -- Make sure that installcheck won't find previous data
 SELECT "PGQS".pg_qualstats_reset();
 
-EXPLAIN (COSTS OFF) SELECT count(*)
+SELECT explain_filter($$EXPLAIN (COSTS OFF) SELECT count(*)
 FROM lineitem, part
 WHERE
     p_partkey = l_partkey
@@ -74,6 +75,7 @@ WHERE
       WHERE
         l_partkey = p_partkey
 );
+$$);
 
 SELECT lc.relname, la.attname,
     opno::regoperator,


### PR DESCRIPTION
Pg19 will introduce some difference in the EXPLAIN output.  For now simply introduce current explain_filter function as-is, and we will modify it as needed when pg19 compatibility will be added.