### PR TITLE
Fix compatibility with pg19

### DIFF
--- a/expected/00_setup.out
+++ b/expected/00_setup.out
@@ -21,6 +21,8 @@ BEGIN
         -- Ignore text-mode "Planning:" line because whether it's output
         -- varies depending on the system state
         CONTINUE WHEN (ln = 'Planning:');
+        -- Remove the "expr_" name prefix in subplans names, added in pg19
+        ln := regexp_replace(ln, 'SubPlan expr_\d+', 'SubPlan N', 'g');
         RETURN NEXT ln;
     END LOOP;
 END;

--- a/pg_qualstats.c
+++ b/pg_qualstats.c
@@ -45,6 +45,7 @@
 #if PG_VERSION_NUM >= 150000
 #include "common/pg_prng.h"
 #endif
+#include "executor/instrument.h"
 #include "fmgr.h"
 #include "funcapi.h"
 #include "mb/pg_wchar.h"
@@ -99,6 +100,14 @@ PG_MODULE_MAGIC;
 #define PGQS_LWL_RELEASE(lock) if (!pgqs_backend) { \
 	LWLockRelease(lock); \
 	}
+
+#if PG_VERSION_NUM < 190000
+/*
+ * pg19 changed the init/max size to a single fixed size, so simulate that
+ * behavior for older versions.
+ */
+#define ShmemInitHash(n, nelem, i, f) ShmemInitHash(n, nelem, nelem, i, f)
+#endif
 
 #if PG_VERSION_NUM < 170000
 #define MyProcNumber MyBackendId
@@ -1054,7 +1063,11 @@ static void
 pgqs_collectNodeStats(PlanState *planstate, List *ancestors, pgqsWalkerContext *context)
 {
 	Plan	   *plan = planstate->plan;
-	Instrumentation *instrument = planstate->instrument;
+#if PG_VERSION_NUM >= 190000
+	NodeInstrumentation *instrument;
+#else
+	Instrumentation *instrument;
+#endif
 	int64		oldcount = context->count;
 	double		oldfiltered = context->nbfiltered;
 	double		old_err_ratio = context->err_estim[PGQS_RATIO];
@@ -1065,6 +1078,7 @@ pgqs_collectNodeStats(PlanState *planstate, List *ancestors, pgqsWalkerContext *
 	List	   *indexquals = 0;
 	List	   *quals = 0;
 
+	instrument = planstate->instrument;
 	context->planstate = planstate;
 
 	/*
@@ -1912,12 +1926,12 @@ pgqs_shmem_startup(void)
 	queryinfo.hash = pgqs_uint32_hashfn;
 #endif
 	pgqs_hash = ShmemInitHash("pg_qualstatements_hash",
-							  pgqs_max, pgqs_max,
+							  pgqs_max,
 							  &info,
 							  HASH_ELEM | HASH_FUNCTION | HASH_FIXED_SIZE);
 
 	pgqs_query_examples_hash = ShmemInitHash("pg_qualqueryexamples_hash",
-											 pgqs_max, pgqs_max,
+											 pgqs_max,
 											 &queryinfo,
 
 /* On PG > 9.5, use the HASH_BLOBS optimization for uint32 keys. */

--- a/test/sql/00_setup.sql
+++ b/test/sql/00_setup.sql
@@ -22,6 +22,8 @@ BEGIN
         -- Ignore text-mode "Planning:" line because whether it's output
         -- varies depending on the system state
         CONTINUE WHEN (ln = 'Planning:');
+        -- Remove the "expr_" name prefix in subplans names, added in pg19
+        ln := regexp_replace(ln, 'SubPlan expr_\d+', 'SubPlan N', 'g');
         RETURN NEXT ln;
     END LOOP;
 END;


### PR DESCRIPTION
Multiple upstream commits broke compatibility:

Since https://github.com/postgres/postgres/commit/fba4233 we now need to explicitly include intrument.h.  Just do it for all version as it's needed no matter what, so relying on indirect inclusion is not the best choice.

https://github.com/postgres/postgres/commit/5a79e78501f4 changed PlanState->instrument type.

https://github.com/postgres/postgres/commit/6ef9bee29310 changed ShmemInitHash signature, removing the init and max size to only a fixed size.  Provide a backward compatibility macro to simulate the same behavior for older versions.

https://github.com/postgres/postgres/commit/8c49a484e8e changed the naming of SubPlan nodes (among other things).  Update our copy of explain_filter to emit the same names as for earlier versions.